### PR TITLE
Minor bug fixes that enable reading matpower cases

### DIFF
--- a/psst/model/__init__.py
+++ b/psst/model/__init__.py
@@ -61,10 +61,14 @@ def build_model(case,
         reserve_factor = config.pop('reserve_factor', 0)
 
     # Get case data
-    generator_df = generator_df or pd.merge(case.gen, case.gencost, left_index=True, right_index=True)
-    load_df = load_df or case.load
-    branch_df = branch_df or case.branch
-    bus_df = bus_df or case.bus
+    if generator_df is None:
+        generator_df = pd.merge(case.gen, case.gencost, left_index=True, right_index=True)
+    if load_df is None:
+        load_df = case.load
+    if branch_df is None:
+        branch_df = case.branch
+    if bus_df is None:
+        bus_df = case.bus
 
     branch_df.index = branch_df.index.astype(object)
     generator_df.index = generator_df.index.astype(object)

--- a/psst/model/__init__.py
+++ b/psst/model/__init__.py
@@ -84,10 +84,10 @@ def build_model(case,
     generator_df['RAMP'] = generator_df['RAMP_10'] * 6
 
     if timeseries_pmax is None:
-        timeseries_pmax = generator_df["PMAX"].to_dict(orient="list")
+        timeseries_pmax = generator_df["PMAX"].to_dict()#orient="list")
 
     if timeseries_pmin is None:
-        timeseries_pmin = generator_df["PMIN"].to_dict(orient="list")
+        timeseries_pmin = generator_df["PMIN"].to_dict()#orient="list")
 
     # Build model information
 

--- a/psst/model/generators.py
+++ b/psst/model/generators.py
@@ -48,7 +48,7 @@ def maximum_minimum_power_output_generators(model, minimum_power_output=None, ma
 
     # TODO add validation that maximum power output is greater than minimum power output
 
-    model.MinimumPowerOutput = Param(model.Generators, model.TimePeriods, initialize=minimum_power_output, within=NonNegativeReals, default=0.0)
+    model.MinimumPowerOutput = Param(model.Generators, model.TimePeriods, initialize=minimum_power_output, within=Reals, default=0.0)
     model.MaximumPowerOutput = Param(model.Generators, model.TimePeriods, initialize=maximum_power_output, within=NonNegativeReals, default=0.0)
 
 

--- a/psst/model/generators.py
+++ b/psst/model/generators.py
@@ -47,7 +47,7 @@ def maximum_minimum_power_output_generators(model, minimum_power_output=None, ma
 
 
     # TODO add validation that maximum power output is greater than minimum power output
-
+    print('Changed model.MinimumPowerOutput to use within=Reals')
     model.MinimumPowerOutput = Param(model.Generators, model.TimePeriods, initialize=minimum_power_output, within=Reals, default=0.0)
     model.MaximumPowerOutput = Param(model.Generators, model.TimePeriods, initialize=maximum_power_output, within=NonNegativeReals, default=0.0)
 
@@ -172,7 +172,7 @@ def _minimum_production_cost_fn(m, g, t):
 
 
 def minimum_production_cost(model, minimum_production_cost=_minimum_production_cost_fn):
-    model.MinimumProductionCost = Param(model.Generators, model.TimePeriods, within=NonNegativeReals, initialize=_minimum_production_cost_fn, mutable=True)
+    model.MinimumProductionCost = Param(model.Generators, model.TimePeriods, within=Reals, initialize=_minimum_production_cost_fn, mutable=True)
 
 
 def quadratic_cost_coefficients(model, production_cost_a=None, production_cost_b=None, production_cost_c=None):

--- a/psst/network/__init__.py
+++ b/psst/network/__init__.py
@@ -127,11 +127,11 @@ class PSSTNetwork(object):
         return self._draw_nodes(nodelist, **kwargs)
 
     def draw_branches(self, **kwargs):
-        edgelist = kwargs.pop('edgelist', [(f, t) for f, t, e in self._G.edges(data=True) if e['kind'] == 'branch'])
+        edgelist = kwargs.pop('edgelist', [(f, t) for f, t, e in self._G.edges(data=True) if 'kind' in e and e['kind'] == 'branch'])
         return self._draw_edges(edgelist, **kwargs)
 
     def draw_connections(self, connection_kind, **kwargs):
-        edgelist = kwargs.pop('edgelist', [(f, t) for f, t, e in self._G.edges(data=True) if e['kind'] == connection_kind])
+        edgelist = kwargs.pop('edgelist', [(f, t) for f, t, e in self._G.edges(data=True) if 'kind' in e and  e['kind'] == connection_kind])
         return self._draw_edges(edgelist, **kwargs)
 
     def _draw_nodes(self, nodelist, **kwargs):

--- a/psst/network/__init__.py
+++ b/psst/network/__init__.py
@@ -127,11 +127,11 @@ class PSSTNetwork(object):
         return self._draw_nodes(nodelist, **kwargs)
 
     def draw_branches(self, **kwargs):
-        edgelist = kwargs.pop('edgelist', [(f, t) for f, t, e in self._G.edges(data=True) if 'kind' in e and e['kind'] == 'branch'])
+        edgelist = kwargs.pop('edgelist', [(f, t) for f, t, e in self._G.edges(data=True) if  e['attr_dict']['kind'] == 'branch'])
         return self._draw_edges(edgelist, **kwargs)
 
     def draw_connections(self, connection_kind, **kwargs):
-        edgelist = kwargs.pop('edgelist', [(f, t) for f, t, e in self._G.edges(data=True) if 'kind' in e and  e['kind'] == connection_kind])
+        edgelist = kwargs.pop('edgelist', [(f, t) for f, t, e in self._G.edges(data=True) if   e['attr_dict']['kind'] == connection_kind])
         return self._draw_edges(edgelist, **kwargs)
 
     def _draw_nodes(self, nodelist, **kwargs):

--- a/psst/utils.py
+++ b/psst/utils.py
@@ -13,7 +13,8 @@ def int_else_float_except_string(s):
         return i if i==f else f
     except ValueError:
         return s
-
+    except OverflowError:
+        return s
 
 def has_number(string):
     return any(c.isdigit() for c in string)


### PR DESCRIPTION
Hi @kdheepak 

This pull request includes some very minor bug fixes that are probably due to recent changes in pandas and networkx that cropped up when trying to execute 'read_matpower()'.

For https://github.com/power-system-simulation-toolbox/psst/commit/7112324002d2ba8c0ddecdc4bcf7916cf447b767

I  changed the `within=NonNegativeReals` to `within=Reals` for line 51 of `generators.py` as you requested.

Also, on lines 87 and 90 of `model/__init__.py` you had
```python
timeseries_pmax = generator_df["PMAX"].to_dict(orient="list")
```

However, `to_dict()` no longer allows the `orient` keyword for Series (although it does for DataFrames)



For https://github.com/power-system-simulation-toolbox/psst/commit/a1c90d1b634dcc4090553e532bbde327e46e4164 
I could not read [`case2383wp`](https://github.com/MATPOWER/matpower/blob/ee27a86a9127538c3013366e3044674c1fe58645/data/case2383wp.m#L2461-L2466) because it contained -Inf and Inf in the Qmin and Qmax, which raised an `OverflowError` instead of a `ValueError` so I added a check for that.

With https://github.com/power-system-simulation-toolbox/psst/commit/a1c90d1b634dcc4090553e532bbde327e46e4164
For some reason networkx no longer allows directly referencing edge attributes by key, so in order to access an edge attribute you have to go through the `attr_dict` first.


Lastly, for https://github.com/power-system-simulation-toolbox/psst/commit/315fc0f03d801428f4818d91ab326f173da54bcc

 `model/__init__.py` 

the idiom 

```python
load_df = load_df or case.load
```
only works if load_df is None. If `load_df` is a dataframe, then this statement generates a `ValueError` because
```python
ValueError: The truth value of a DataFrame is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().
```

So to fix this, I explicitly check to see if the dataframe is None and then only perform the assignment if it is.
